### PR TITLE
feat: reconnect on close

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -149,11 +149,11 @@ class Phase extends Extension {
     public version = "v1.0";
     public static order = 2;
     private _rabbit: RabbitMQ;
-    private _logger: Winston.Logger;
+    private _amqpLogger: Winston.Logger;
 
     constructor(server: TerrariaServer) {
         super(server);
-        this._logger = server.logger.child({
+        this._amqpLogger = server.logger.child({
             name: "Phase.AMQPConnection"
         });
         this._rabbit = new RabbitMQ(server.logger);
@@ -405,9 +405,9 @@ class Phase extends Extension {
         // error is not null in the case of a server-initiated close or an error
         // http://www.squaremobius.net/amqp.node/channel_api.html#model_events
         if (error) {
-            this._logger.error("AMQP Connection closed", error);
+            this._amqpLogger.error("AMQP Connection closed", error);
         } else {
-            this._logger.info("AMQP Connection closed");
+            this._amqpLogger.info("AMQP Connection closed");
         }
 
         // Reconnect

--- a/app/index.ts
+++ b/app/index.ts
@@ -153,6 +153,7 @@ class Phase extends Extension {
         super(server);
         this._rabbit = new RabbitMQ(server.logger);
         this._rabbit.on("connected", () => this.onConnect());
+        this._rabbit.on("close", (e) => this.onClose(e));
         this.doConnect();
     }
 
@@ -393,6 +394,19 @@ class Phase extends Extension {
                 accountName: user !== null ? user.name : ""
             }));
         }
+    }
+
+    private onClose(error?: any) {
+        // error is not null in the case of a server-initiated close or an error
+        // http://www.squaremobius.net/amqp.node/channel_api.html#model_events
+        if (error) {
+            console.error("AMQP Connection closed", error);
+        } else {
+            console.info("AMQP Connection closed");
+        }
+
+        // Reconnect
+        this.doConnect();
     }
 }
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -6,6 +6,7 @@ import Extension from "terrariaserver-lite/extensions/extension";
 import { config } from "./configloader";
 import RabbitMQ from "./rabbitmq";
 import * as util from "util";
+import * as Winston from "winston";
 
 interface PhaseMessage {
     token: string;
@@ -148,9 +149,13 @@ class Phase extends Extension {
     public version = "v1.0";
     public static order = 2;
     private _rabbit: RabbitMQ;
+    private _logger: Winston.Logger;
 
     constructor(server: TerrariaServer) {
         super(server);
+        this._logger = server.logger.child({
+            name: "Phase.AMQPConnection"
+        });
         this._rabbit = new RabbitMQ(server.logger);
         this._rabbit.on("connected", () => this.onConnect());
         this._rabbit.on("close", (e) => this.onClose(e));
@@ -400,9 +405,9 @@ class Phase extends Extension {
         // error is not null in the case of a server-initiated close or an error
         // http://www.squaremobius.net/amqp.node/channel_api.html#model_events
         if (error) {
-            console.error("AMQP Connection closed", error);
+            this._logger.error("AMQP Connection closed", error);
         } else {
-            console.info("AMQP Connection closed");
+            this._logger.info("AMQP Connection closed");
         }
 
         // Reconnect

--- a/app/rabbitmq.ts
+++ b/app/rabbitmq.ts
@@ -44,6 +44,7 @@ class RabbitMQ extends EventEmitter {
             this._logger.error(`RabbitMQ connection error: ${e.toString()}`);
             reject(e);
           });
+          this._connection.on("close", (e) => this.emit("close", e));
           this._channel = await this.createChannel();
           this.emit("connected");
         });


### PR DESCRIPTION
Rarely, the RabbitMQ server can have issues and drop some connections. Or, TSL-Phase connection can be closed due to an internal error. This PR aims to fix that by making TSL-Phase reconnect when the connection closed.

TSL-Phase does this by calling `doConnect()`, the same connection loop called by the constructor.

Here is a list of all changes:
- Makes RabbitMQ re-emit `close` event from `_connection`
- Makes TSL-Phase hook onto `close`
- Calls `doConnect()` when the connection closes
- Adds a logger to TSL-Phase for AMQP logging